### PR TITLE
[Feature] Clear-able (v1.0.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > :clock1: The dynamic setInterval
 
-Exactly like the all-familiar `setInterval` except that it also accepts a function that allows you calculate a new interval size on each iteration / tick.
+Just like the all-familiar `setInterval` except that it also accepts a function that allows you calculate a new interval size on each iteration / tick.
 
 Also referred to as a "dynterval".
 
@@ -15,7 +15,7 @@ This script doubles the amount of time between intervals on each iteration, star
 // `wait` is what's used to determine the duration between each interval
 const config = { wait: 50 }
 
-setDynterval(interval => {
+const dynterval = setDynterval(interval => {
   console.log('interval', interval)
 
   return { wait: interval.wait * 2 }
@@ -25,6 +25,12 @@ setDynterval(interval => {
 // interval { wait: 100 }
 // interval { wait: 200 }
 // ...
+
+// clear out the interval after 2 seconds
+// NOTE: clearInterval is not compatible, use the `clear` method instead
+setTimeout(() => {
+  dynterval.clear()
+}, 2000)
 ```
 
 ## License

--- a/dist/index.js
+++ b/dist/index.js
@@ -27,7 +27,16 @@ var setDynterval = exports.setDynterval = function setDynterval(next, config) {
 
   var interval = setInterval(step, context.wait);
 
-  return interval;
+  // return interval
+  return {
+    get current() {
+      return interval;
+    },
+
+    clear: function clear() {
+      clearInterval(interval);
+    }
+  };
 };
 
 exports.default = setDynterval;

--- a/index.js
+++ b/index.js
@@ -22,7 +22,16 @@ export const setDynterval = (next, config) => {
 
   let interval = setInterval(step, context.wait)
 
-  return interval
+  // return interval
+  return {
+    get current () {
+      return interval
+    },
+
+    clear () {
+      clearInterval(interval)
+    }
+  }
 }
 
 export default setDynterval

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamic-interval",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "description": "setInterval but with a dynamic interval that can change on each tick",
   "main": "dist/index.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 const setDynterval = require('./dist/index').setDynterval
 
-setDynterval(ctx => {
+const test = setDynterval(ctx => {
   console.log('waiting', ctx.wait, ctx.direction)
 
   if (ctx.direction === 'up') {
@@ -20,3 +20,11 @@ setDynterval(ctx => {
   // return ctx.wait
   return ctx
 }, { wait: 50, direction: 'up' })
+
+console.log('! set interval', test)
+
+setTimeout(() => {
+  console.log('! cleared interval', test)
+
+  clearInterval(test)
+}, 4000)

--- a/test.js
+++ b/test.js
@@ -26,5 +26,7 @@ console.log('! set interval', test)
 setTimeout(() => {
   console.log('! cleared interval', test)
 
-  clearInterval(test)
+  test.clear()
+
+  setTimeout(() => console.log('done'), 1000)
 }, 4000)


### PR DESCRIPTION
Intervals are now (actually) clear-able.

Before, `clearInterval` would sort of work but only on the first step, because the trick I used to make this lib involves breaking reference to the original variable

In order to support clearing functionality, I had to add a `.clear` method, breaking "compatibility" (which, again, never full worked) with `clearInterval`